### PR TITLE
Change app created flag

### DIFF
--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -8,7 +8,7 @@ fresh_container() {
 }
 
 app_present() {
-  [ -f /app/config/database.yml ]
+  [ -f /app/config.ru ]
 }
 
 gems_up_to_date() {


### PR DESCRIPTION
The problem is that if you remove or ignore the database.yml (which can be a common practice), the entry-point thinks that you do not have an application. @prydonius @sameersbn 