### PR TITLE
Rails image doesn't include mysql binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin:$PATH
 
 
 RUN bitnami-pkg install imagemagick-6.7.5-10-3 --checksum 617e85a42c80f58c568f9bc7337e24c03e35cf4c7c22640407a7e1e16880cf88
-RUN bitnami-pkg install mysql-libraries-10.1.13-0 --checksum 71ca428b619901123493503f8a99ccfa588e5afddd26e0d503a32cca1bc2a389
+RUN bitnami-pkg install mysql-libraries-10.1.19-0 --checksum 6729ab22f06052af981b0a78e9f4a700d4cbc565d771e9c6c874f1f57fdb76d2
 RUN bitnami-pkg install mysql-client-10.1.19-0 --checksum fdbc292bedabeaf0148d66770b8aa0ab88012ce67b459d6ba2b46446c91bb79c
 
 # Ruby on Rails template

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,14 @@ ENV STACKSMITH_STACK_ID="hw4vyh1" \
 
 RUN bitnami-pkg install ruby-2.3.1-2 --checksum 041625b9f363a99b2e66f0209a759abe7106232e0fcc3a970958bf73d5a4d9b0
 
-ENV PATH=/opt/bitnami/ruby/bin:$PATH
+ENV PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin:$PATH
 
 ## STACKSMITH-END: Modifications below this line will be unchanged when regenerating
 
 
 RUN bitnami-pkg install imagemagick-6.7.5-10-3 --checksum 617e85a42c80f58c568f9bc7337e24c03e35cf4c7c22640407a7e1e16880cf88
 RUN bitnami-pkg install mysql-libraries-10.1.13-0 --checksum 71ca428b619901123493503f8a99ccfa588e5afddd26e0d503a32cca1bc2a389
+RUN bitnami-pkg install mysql-client-10.1.19-0 --checksum fdbc292bedabeaf0148d66770b8aa0ab88012ce67b459d6ba2b46446c91bb79c
 
 # Ruby on Rails template
 RUN gem install rails -v 5.0.0.1 --no-document


### PR DESCRIPTION
Rails has a `dbconsole` command that starts a session for querying the db directly.

Trying this gives

    Couldn't find database client: mysql, mysql5. Check your $PATH and try again.

It's a case where the config dictates what is needed, but maybe because the `docker-compose.yml` defaults to mariadb the rails image should include the `mysql` binary?