### PR TITLE
(Feat) Skip DB migration, setup and waiting using env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN gem install therubyracer
 
 ENV RAILS_ENV=development
 ENV BITNAMI_APP_NAME=rails
-ENV BITNAMI_IMAGE_VERSION=5.0.0.1-r3
+ENV BITNAMI_IMAGE_VERSION=5.0.0.1-r4
 
 USER bitnami
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -117,6 +117,34 @@ Following are a few examples of launching some commonly used Rails development c
   > $ docker-compose restart myapp
   > ```
 
+## Running additional services:
+
+  Sometimes, your application will require extra pieces, such as background processing tools like Resque
+or Sidekiq.
+
+  For these cases, it is possible to re-use this container to be run as an additional
+service in your docker-compose file by modifying the command
+executed.
+
+For example, you could run a Sidekiq container by adding the following to your
+`docker-compose.yml` file:
+
+```yaml
+services:
+  ...
+  sidekiq:
+    image: bitnami/rails:latest
+    environment:
+      # This skips the execution of rake db:create and db:migrate
+      # since it is being executed by the rails service.
+      - SKIP_DB_SETUP=true
+    command: bundle exec sidekiq
+```
+
+> **Note**
+>
+> You can skip database wait period and creation/migration by setting the SKIP_DB_WAIT and SKIP_DB_SETUP environment variables.
+
 ## Installing Rubygems
 
 To add a Rubygem to your application, update the `Gemfile` in the application directory as you would normally do and restart the `myapp` service container.

--- a/rootfs/app-entrypoint.sh
+++ b/rootfs/app-entrypoint.sh
@@ -58,7 +58,7 @@ if [ "$1" == "bundle" -a "$2" == "exec" ]; then
     log "Gems updated"
   fi
 
-  wait_for_db
+  [[ -z $SKIP_DB_WAIT ]] && wait_for_db
 
   if ! fresh_container; then
     echo "#########################################################################"
@@ -70,12 +70,14 @@ if [ "$1" == "bundle" -a "$2" == "exec" ]; then
     echo "                                                                       "
     echo "#########################################################################"
   else
-    setup_db
+
+    [[ -z $SKIP_DB_SETUP ]] && setup_db
+
     log "Initialization finished"
     touch $INIT_SEM
   fi
 
-  migrate_db
+  [[ -z $SKIP_DB_SETUP ]] && migrate_db
 fi
 
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
This allow to run custom ruby commands without worrying on race conditions on `db:create` and `db:migrate`

For example, having this additional sidekiq service now it will not crash under the race condition described.

```yaml
  sidekiq:
    extends:
      file: docker-compose-common.yml
      service: rails_runtime
    depends_on:
      - mariadb
      - redis
    environment:
      - SKIP_DB_SETUP=true
    command: bundle exec sidekiq -C config/sidekiq.yml
```