### PR TITLE
update Rails to 5.1.1

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,17 +1,17 @@
-FROM bitnami/minideb-extras:jessie-r13-buildpack
+FROM bitnami/minideb-extras:jessie-r15-buildpack
 
 MAINTAINER Bitnami <containers@bitnami.com>
 
 # System packages required
-RUN install_packages libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libmysqlclient-dev libpq5
+RUN install_packages ghostscript imagemagick libc6 libffi6 libgcc1 libgmp-dev libmysqlclient18 libmysqlclient-dev libncurses5 libpq5 libreadline6 libssl1.0.0 libssl1.0.0 libstdc++6 libtinfo5 libxml2-dev libxslt1-dev zlib1g zlib1g-dev
 
-RUN bitnami-pkg install ruby-2.4.0-1 --checksum c42ef6b39fe67b3fc60e41e42aa5d3a39de0f714069369a15342ceed0b53a6a5
-RUN bitnami-pkg install mysql-client-10.1.21-3 --checksum 9f636d5c4f0c734290ecbb93b51dd71bb81674fee14c3e517ec4f9440bb26bcb
+RUN bitnami-pkg install ruby-2.4.1-0 --checksum eaf2341624588774f61e4aac4f53c437e98b1e97f6915ba6327d3ecdc6c2c3a2
+RUN bitnami-pkg install mysql-client-10.1.23-1 --checksum 0be92fcc4f7fec93edfa7f788e2bbb87b5b3aac92dfdec159a10590345362512
 
 ENV PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin:$PATH
 
 # Ruby on Rails template
-RUN gem install rails -v 5.0.2 --no-document
+RUN gem install rails -v 5.1.1 --no-document
 
 # Bundle the gems required for a new application
 RUN rails new /tmp/temp_app --database mysql --quiet && rm -r /tmp/temp_app
@@ -19,7 +19,7 @@ RUN gem install therubyracer
 
 ENV RAILS_ENV=development
 ENV BITNAMI_APP_NAME=rails
-ENV BITNAMI_IMAGE_VERSION=5.0.2-r1
+ENV BITNAMI_IMAGE_VERSION=5.1.1-r0
 
 COPY rootfs/ /
 


### PR DESCRIPTION
This updates the Rails image to `5.1.1-r0`

# Notable changes
- Update Rails to `5.1.1`
- Update base image to `bitnami/minideb-extras:jessie-r15-buildpack`
- Update system requirements