### PR TITLE
bump image to version 5.1.2-r0

### DIFF
--- a/.codenvy.dockerfile
+++ b/.codenvy.dockerfile
@@ -1,28 +1,27 @@
-FROM gcr.io/stacksmith-images/minideb-buildpack:jessie-r8
+FROM bitnami/minideb-extras:jessie-r19-buildpack
 
 MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y openjdk-8-jdk-headless
+RUN install_packages -t jessie-backports -y openjdk-8-jdk-headless ghostscript
 RUN install_packages git subversion openssh-server rsync
 RUN mkdir /var/run/sshd && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 # System packages required
-RUN install_packages libc6 libaio1 zlib1g libjemalloc1 libssl1.0.0 libstdc++6 libgcc1 libncurses5 libtinfo5
+RUN install_packages imagemagick libaio1 libjemalloc1 libc6 libffi6 libgcc1 libgmp-dev libmysqlclient18 libmysqlclient-dev libncurses5 libpq5 libreadline6 libssl1.0.0 libstdc++6 libtinfo5 libxml2-dev libxslt1-dev zlib1g zlib1g-dev netcat-traditional
 
 ENV BITNAMI_APP_NAME=che-rails \
-    BITNAMI_IMAGE_VERSION=5.0.0.1-r9 \
+    BITNAMI_IMAGE_VERSION=5.1.2-r0 \
     RAILS_ENV=development \
     PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin/:$PATH
 
 # Install Rails dependencies
-RUN bitnami-pkg install ruby-2.3.1-2 --checksum 041625b9f363a99b2e66f0209a759abe7106232e0fcc3a970958bf73d5a4d9b0
-RUN bitnami-pkg install imagemagick-6.7.5-10-3 --checksum 617e85a42c80f58c568f9bc7337e24c03e35cf4c7c22640407a7e1e16880cf88
-RUN bitnami-pkg install mysql-libraries-10.1.19-0 --checksum 6729ab22f06052af981b0a78e9f4a700d4cbc565d771e9c6c874f1f57fdb76d2
-RUN bitnami-pkg install mariadb-10.1.20-0 --checksum 7409ba139885bc4f463233a250806f557ee41472e2c88213e82c21f4d97a77d7
+RUN bitnami-pkg install ruby-2.4.1-0 --checksum eaf2341624588774f61e4aac4f53c437e98b1e97f6915ba6327d3ecdc6c2c3a2
+RUN bitnami-pkg install mysql-client-10.1.24-0 --checksum 3ac33998eefe09a8013036d555f2a8265fc446a707e8d61c63f8621f4a3e5dae
+RUN bitnami-pkg install mariadb-10.1.24-1 --checksum 0ad8567f9d3d8371f085b56854b5288be38c85a5cb3cd4e36d8355eb6bbbd4cd -- --allowEmptyPassword yes
 
 # Ruby on Rails template
-RUN gem install rails -v 5.0.0.1 --no-document
+RUN gem install rails -v 5.1.2 --no-document
 
 # Rails template
 RUN rails new /tmp/temp_app --database mysql --quiet && rm -r /tmp/temp_app

--- a/.codenvy.json
+++ b/.codenvy.json
@@ -5,7 +5,7 @@
       "default": {
         "recipe": {
           "type": "dockerimage",
-          "location": "bitnami/che-rails:5.0.0.1-r9"
+          "location": "bitnami/che-rails:5.1.2-r0"
         },
         "machines": {
           "ws-machine": {


### PR DESCRIPTION
**Description of the change**

Updates the image to version 5.1.2-r0

**Benefits**

Up-to-date version of Rails and minideb

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None