### PR TITLE
Set default database host to mariadb

### DIFF
--- a/5/rootfs/app-entrypoint.sh
+++ b/5/rootfs/app-entrypoint.sh
@@ -35,7 +35,6 @@ wait_for_db() {
 
 setup_db() {
   log "Configuring the database"
-  sed -i 's/host: localhost/host: mariadb/g' /app/config/database.yml
   bundle exec rails db:create
 }
 
@@ -50,6 +49,8 @@ if [ "$1" == "bundle" -a "$2" == "exec" ]; then
     rails new . --skip-bundle --database mysql
     # Add rubyracer
     sed -i "s/# gem 'therubyracer'/gem 'therubyracer'/" Gemfile
+    log "Setting default host to \`mariadb\`"
+    sed -i 's/host:.*$/host: mariadb/g' /app/config/database.yml
   fi
 
   if ! gems_up_to_date; then

--- a/5/rootfs/app-entrypoint.sh
+++ b/5/rootfs/app-entrypoint.sh
@@ -35,6 +35,7 @@ wait_for_db() {
 
 setup_db() {
   log "Configuring the database"
+  sed -i 's/host: localhost/host: mariadb/g' /app/config/database.yml
   bundle exec rails db:create
 }
 


### PR DESCRIPTION
**Description of the change**

This change sets the default database host in database.yml to `mariadb`.

**Benefits**
The test db will be also created on startup.

**Possible drawbacks**

The service name is hardcoded in the entrypoint

**Applicable issues**

https://github.com/bitnami/bitnami-docker-rails/issues/61

