### PR TITLE
Bump image to version 5.1.4-r0

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb-extras:jessie-r21-buildpack
+FROM bitnami/minideb-extras:jessie-r22-buildpack
 
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -5,13 +5,13 @@ LABEL maintainer "Bitnami <containers@bitnami.com>"
 # System packages required
 RUN install_packages ghostscript imagemagick libc6 libffi6 libgcc1 libgmp-dev libmysqlclient18 libmysqlclient-dev libncurses5 libpq5 libreadline6 libssl1.0.0 libssl1.0.0 libstdc++6 libtinfo5 libxml2-dev libxslt1-dev zlib1g zlib1g-dev netcat-traditional
 
-RUN bitnami-pkg install ruby-2.4.1-0 --checksum eaf2341624588774f61e4aac4f53c437e98b1e97f6915ba6327d3ecdc6c2c3a2
+RUN bitnami-pkg install ruby-2.4.1-1 --checksum 0b82f1457328b3c45daaa1adb89970087acac75f4d015a7e173906268877da02
 RUN bitnami-pkg install mysql-client-10.1.26-0 --checksum 731e07b76a06c8b7f2a0b79d528f2f1f37e49142f682ab27ab8f4edfc9176d83
 
 ENV PATH=/opt/bitnami/ruby/bin:/opt/bitnami/mysql/bin:$PATH
 
 # Ruby on Rails template
-RUN gem install rails -v 5.1.3 --no-document
+RUN gem install rails -v 5.1.4 --no-document
 
 # Bundle the gems required for a new application
 RUN rails new /tmp/temp_app --database mysql --quiet && rm -r /tmp/temp_app
@@ -19,7 +19,7 @@ RUN gem install therubyracer
 
 ENV RAILS_ENV=development
 ENV BITNAMI_APP_NAME=rails
-ENV BITNAMI_IMAGE_VERSION=5.1.3-r0
+ENV BITNAMI_IMAGE_VERSION=5.1.4-r0
 
 COPY rootfs/ /
 


### PR DESCRIPTION
Update Ruby on Rails to version 5.1.4
Update Rubygems bundled with Ruby to version 2.6.13, which includes several security fixes:

Fix a DNS request hijacking vulnerability
Fix an ANSI escape sequence vulnerability
Fix a DOS vulernerability in the query command
Fix a vulnerability in the gem installer that allowed a malicious gem to overwrite arbitrary files