### PR TITLE
Allow configuring MariaDB hostname instead of hardcoding it to 'mariadb'

### DIFF
--- a/5/debian-9/Dockerfile
+++ b/5/debian-9/Dockerfile
@@ -7,6 +7,8 @@ RUN bitnami-pkg install ruby-2.4.5-20 --checksum f1496dcc6b4fce4c661c6af478ac989
 RUN bitnami-pkg install mysql-client-10.1.37-20 --checksum 414e98c1024187f1f0300eb3571f3d5ae54cdb36f3f08430be634714700bd1d9
 RUN bitnami-pkg install git-2.19.2-0 --checksum 24817a90223cfc91ce38cdc459dc6647dcf36754bf0300433ddb00ec276757ff
 RUN bitnami-pkg install rails-5.2.2-20 --checksum d29500cbf2d1a31a9101b2594b0034be8e0c1dedfc86b373a62b3d82d5954236
+RUN curl -sLo yq https://github.com/mikefarah/yq/releases/download/2.2.0/yq_linux_amd64 && \
+    chmod +x yq && mv yq /usr/local/bin/
 RUN mkdir /app && chown bitnami:bitnami /app
 
 COPY rootfs /

--- a/5/debian-9/docker-compose.yml
+++ b/5/debian-9/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     tty: true # Enables debugging capabilities when attached to this container.
     image: bitnami/rails:5-debian-9
     environment:
-      - DATABASE_URL=mysql2://mariadb/my_app_development
+      - MARIADB_HOST=mariadb
+      - MARIADB_DATABASE=my_app_development
     depends_on:
       - mariadb
     ports:

--- a/5/debian-9/docker-compose.yml
+++ b/5/debian-9/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     tty: true # Enables debugging capabilities when attached to this container.
     image: bitnami/rails:5-debian-9
     environment:
-      - MARIADB_HOST=mariadb
-      - MARIADB_DATABASE=my_app_development
+      - DATABASE_HOST=mariadb
+      - DATABASE_NAME=my_app_development
     depends_on:
       - mariadb
     ports:

--- a/5/debian-9/rootfs/app-entrypoint.sh
+++ b/5/debian-9/rootfs/app-entrypoint.sh
@@ -1,30 +1,47 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+# set -o xtrace
+# shellcheck disable=SC1091
+
+# Load libraries
 . /opt/bitnami/base/functions
 
-print_welcome_page
-
+# Constants
 INIT_SEM=/tmp/initialized.sem
 
-fresh_container() {
-  [ ! -f $INIT_SEM ]
-}
+# Functions
 
-app_present() {
-  [ -f /app/config.ru ]
-}
-
+########################
+# Ensure gems are up to date
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+#########################
 gems_up_to_date() {
   bundle check 1> /dev/null
 }
 
+########################
+# Wait for database to be ready
+# Globals:
+#   DATABASE_URL
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 wait_for_db() {
-  mariadb_address=$(getent hosts mariadb | awk '{ print $1 }')
+  local mariadb_host="$(yq r /app/config/database.yml default.host)"
+  local mariadb_address="$(getent hosts $mariadb_host | awk '{ print $1 }')"
   counter=0
-  log "Connecting to mariadb at $mariadb_address"
-  while ! nc -z mariadb 3306; do
+  log "Connecting to MariaDB at $mariadb_address"
+  while ! nc -z "$mariadb_host" 3306; do
     counter=$((counter+1))
     if [ $counter == 30 ]; then
-      log "Error: Couldn't connect to mariadb."
+      log "Error: Couldn't connect to MariaDB."
       exit 1
     fi
     log "Trying to connect to mariadb at $mariadb_address. Attempt $counter."
@@ -32,35 +49,37 @@ wait_for_db() {
   done
 }
 
-setup_db() {
-  log "Configuring the database"
-  bundle exec rails db:create
-}
+print_welcome_page
 
-migrate_db() {
-  log "Applying database migrations (db:migrate)"
-  bundle exec rails db:migrate
-}
-
-if [ "$1" == "bundle" -a "$2" == "exec" ]; then
-  if ! app_present; then
-    log "Creating rails application"
+if [[ "$1" = "bundle" ]] && [[ "$2" = "exec" ]]; then
+  if [[ -f /app/config.ru ]]; then
+    log "Rails project found. Skipping creation..."
+  else
+    log "Creating new Rails project..."
     rails new . --skip-bundle --database mysql
     # Add mini_racer
-    sed -i "s/# gem 'mini_racer'/gem 'mini_racer'/" Gemfile
-    log "Setting default host to \`mariadb\`"
-    sed -i 's/host:.*$/host: mariadb/g' /app/config/database.yml
+    sed -i -e "s/# gem 'mini_racer'/gem 'mini_racer'/" Gemfile
+    # TODO: substitution using 'yq' once they support anchors
+    # Related issue: https://github.com/mikefarah/yq/issues/178
+    # E.g: yq w -i /app/config/database.yml default.host "${MARIADB_HOST:-mariadb}"
+    # E.g: yq w -i /app/config/database.yml development.database "${MARIADB_HOST:-app_development}"
+    log "Setting default host to \`${MARIADB_HOST:-mariadb}\`..."
+    sed -i -e "s/host:.*$/host: ${MARIADB_HOST:-mariadb}/g" /app/config/database.yml
+    log "Setting development database to \`${MARIADB_DATABASE:-my_app_development}\`..."
+    sed -i -e "1,/test:/ s/database:.*$/database: ${MARIADB_DATABASE:-my_app_development}/g" /app/config/database.yml
   fi
 
   if ! gems_up_to_date; then
-    log "Installing/Updating Rails dependencies (gems)"
+    log "Installing/Updating Rails dependencies (gems)..."
     bundle install
-    log "Gems updated"
+    log "Gems updated"!!
   fi
 
-  [[ -z $SKIP_DB_WAIT ]] && wait_for_db
+  if [[ -z $SKIP_DB_WAIT ]]; then
+    wait_for_db
+  fi
 
-  if ! fresh_container; then
+  if [[ -f $INIT_SEM ]]; then
     echo "#########################################################################"
     echo "                                                                       "
     echo " App initialization skipped:"
@@ -70,14 +89,18 @@ if [ "$1" == "bundle" -a "$2" == "exec" ]; then
     echo "                                                                       "
     echo "#########################################################################"
   else
-
-    [[ -z $SKIP_DB_SETUP ]] && setup_db
-
-    log "Initialization finished"
+    if [[ -z $SKIP_DB_SETUP ]]; then
+      log "Configuring the database..."
+      bundle exec rails db:create
+    fi
+    log "Initialization finished!!!"
     touch $INIT_SEM
   fi
 
-  [[ -z $SKIP_DB_SETUP ]] && migrate_db
+  if [[ -z $SKIP_DB_SETUP ]]; then
+    log "Applying database migrations (db:migrate)..."
+    bundle exec rails db:migrate
+  fi
 fi
 
 exec tini -- "$@"

--- a/5/debian-9/rootfs/app-entrypoint.sh
+++ b/5/debian-9/rootfs/app-entrypoint.sh
@@ -27,7 +27,7 @@ gems_up_to_date() {
 ########################
 # Wait for database to be ready
 # Globals:
-#   DATABASE_URL
+#   DATABASE_HOST
 # Arguments:
 #   None
 # Returns:
@@ -72,7 +72,7 @@ if [[ "$1" = "bundle" ]] && [[ "$2" = "exec" ]]; then
   if ! gems_up_to_date; then
     log "Installing/Updating Rails dependencies (gems)..."
     bundle install
-    log "Gems updated"!!
+    log "Gems updated!!"
   fi
 
   if [[ -z $SKIP_DB_WAIT ]]; then

--- a/5/ol-7/Dockerfile
+++ b/5/ol-7/Dockerfile
@@ -7,6 +7,8 @@ RUN bitnami-pkg install ruby-2.4.5-20 --checksum f26eeb2bba7058b2327d6587e02911b
 RUN bitnami-pkg install mysql-client-10.1.37-20 --checksum 916d5a9a191d3a704d9c586a83d8a79348d298e21dff4754feb47a01bf2e5f26
 RUN bitnami-pkg install git-2.19.2-0 --checksum 0d98ba10081908724152c819b0b7ddec46329319fca45182e4a2a50d0c2e49b9
 RUN bitnami-pkg install rails-5.2.2-20 --checksum 36a04178c9906755575a7b1af50ff267cab5489d4e9bbebb397c7f690a36036a
+RUN curl -sLo yq https://github.com/mikefarah/yq/releases/download/2.2.0/yq_linux_amd64 && \
+    chmod +x yq && mv yq /usr/local/bin/
 RUN mkdir /app && chown bitnami:bitnami /app
 
 COPY rootfs /

--- a/5/ol-7/docker-compose.yml
+++ b/5/ol-7/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     tty: true # Enables debugging capabilities when attached to this container.
     image: bitnami/rails:5-ol-7
     environment:
-      - DATABASE_URL=mysql2://mariadb/my_app_development
+      - MARIADB_HOST=mariadb
+      - MARIADB_DATABASE=my_app_development
     depends_on:
       - mariadb
     ports:

--- a/5/ol-7/docker-compose.yml
+++ b/5/ol-7/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     tty: true # Enables debugging capabilities when attached to this container.
     image: bitnami/rails:5-ol-7
     environment:
-      - MARIADB_HOST=mariadb
-      - MARIADB_DATABASE=my_app_development
+      - DATABASE_HOST=mariadb
+      - DATABASE_NAME=my_app_development
     depends_on:
       - mariadb
     ports:

--- a/5/ol-7/rootfs/app-entrypoint.sh
+++ b/5/ol-7/rootfs/app-entrypoint.sh
@@ -1,30 +1,47 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+# set -o xtrace
+# shellcheck disable=SC1091
+
+# Load libraries
 . /opt/bitnami/base/functions
 
-print_welcome_page
-
+# Constants
 INIT_SEM=/tmp/initialized.sem
 
-fresh_container() {
-  [ ! -f $INIT_SEM ]
-}
+# Functions
 
-app_present() {
-  [ -f /app/config.ru ]
-}
-
+########################
+# Ensure gems are up to date
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+#########################
 gems_up_to_date() {
   bundle check 1> /dev/null
 }
 
+########################
+# Wait for database to be ready
+# Globals:
+#   DATABASE_URL
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 wait_for_db() {
-  mariadb_address=$(getent hosts mariadb | awk '{ print $1 }')
+  local mariadb_host="$(yq r /app/config/database.yml default.host)"
+  local mariadb_address="$(getent hosts $mariadb_host | awk '{ print $1 }')"
   counter=0
-  log "Connecting to mariadb at $mariadb_address"
-  while ! nc -z mariadb 3306; do
+  log "Connecting to MariaDB at $mariadb_address"
+  while ! nc -z "$mariadb_host" 3306; do
     counter=$((counter+1))
     if [ $counter == 30 ]; then
-      log "Error: Couldn't connect to mariadb."
+      log "Error: Couldn't connect to MariaDB."
       exit 1
     fi
     log "Trying to connect to mariadb at $mariadb_address. Attempt $counter."
@@ -32,35 +49,37 @@ wait_for_db() {
   done
 }
 
-setup_db() {
-  log "Configuring the database"
-  bundle exec rails db:create
-}
+print_welcome_page
 
-migrate_db() {
-  log "Applying database migrations (db:migrate)"
-  bundle exec rails db:migrate
-}
-
-if [ "$1" == "bundle" -a "$2" == "exec" ]; then
-  if ! app_present; then
-    log "Creating rails application"
+if [[ "$1" = "bundle" ]] && [[ "$2" = "exec" ]]; then
+  if [[ -f /app/config.ru ]]; then
+    log "Rails project found. Skipping creation..."
+  else
+    log "Creating new Rails project..."
     rails new . --skip-bundle --database mysql
     # Add mini_racer
-    sed -i "s/# gem 'mini_racer'/gem 'mini_racer'/" Gemfile
-    log "Setting default host to \`mariadb\`"
-    sed -i 's/host:.*$/host: mariadb/g' /app/config/database.yml
+    sed -i -e "s/# gem 'mini_racer'/gem 'mini_racer'/" Gemfile
+    # TODO: substitution using 'yq' once they support anchors
+    # Related issue: https://github.com/mikefarah/yq/issues/178
+    # E.g: yq w -i /app/config/database.yml default.host "${MARIADB_HOST:-mariadb}"
+    # E.g: yq w -i /app/config/database.yml development.database "${MARIADB_HOST:-app_development}"
+    log "Setting default host to \`${MARIADB_HOST:-mariadb}\`..."
+    sed -i -e "s/host:.*$/host: ${MARIADB_HOST:-mariadb}/g" /app/config/database.yml
+    log "Setting development database to \`${MARIADB_DATABASE:-my_app_development}\`..."
+    sed -i -e "1,/test:/ s/database:.*$/database: ${MARIADB_DATABASE:-my_app_development}/g" /app/config/database.yml
   fi
 
   if ! gems_up_to_date; then
-    log "Installing/Updating Rails dependencies (gems)"
+    log "Installing/Updating Rails dependencies (gems)..."
     bundle install
-    log "Gems updated"
+    log "Gems updated"!!
   fi
 
-  [[ -z $SKIP_DB_WAIT ]] && wait_for_db
+  if [[ -z $SKIP_DB_WAIT ]]; then
+    wait_for_db
+  fi
 
-  if ! fresh_container; then
+  if [[ -f $INIT_SEM ]]; then
     echo "#########################################################################"
     echo "                                                                       "
     echo " App initialization skipped:"
@@ -70,14 +89,18 @@ if [ "$1" == "bundle" -a "$2" == "exec" ]; then
     echo "                                                                       "
     echo "#########################################################################"
   else
-
-    [[ -z $SKIP_DB_SETUP ]] && setup_db
-
-    log "Initialization finished"
+    if [[ -z $SKIP_DB_SETUP ]]; then
+      log "Configuring the database..."
+      bundle exec rails db:create
+    fi
+    log "Initialization finished!!!"
     touch $INIT_SEM
   fi
 
-  [[ -z $SKIP_DB_SETUP ]] && migrate_db
+  if [[ -z $SKIP_DB_SETUP ]]; then
+    log "Applying database migrations (db:migrate)..."
+    bundle exec rails db:migrate
+  fi
 fi
 
 exec tini -- "$@"

--- a/5/ol-7/rootfs/app-entrypoint.sh
+++ b/5/ol-7/rootfs/app-entrypoint.sh
@@ -27,7 +27,7 @@ gems_up_to_date() {
 ########################
 # Wait for database to be ready
 # Globals:
-#   DATABASE_URL
+#   DATABASE_HOST
 # Arguments:
 #   None
 # Returns:
@@ -72,7 +72,7 @@ if [[ "$1" = "bundle" ]] && [[ "$2" = "exec" ]]; then
   if ! gems_up_to_date; then
     log "Installing/Updating Rails dependencies (gems)..."
     bundle install
-    log "Gems updated"!!
+    log "Gems updated!!"
   fi
 
   if [[ -z $SKIP_DB_WAIT ]]; then

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Finally launch the Rails application development environment using:
 $ docker-compose up
 ```
 
-Among other things, the above command creates a container service, named `myapp`, for Rails development and bootstraps a new Rails application in the application directory. You can use your favorite IDE for developing the application.
+Among other things, the above command creates a container service, named `myapp`, for Rails development and bootstraps a new Rails application in the application directory. You can use your favourite IDE for developing the application.
 
 > **Note**
 >
 > If the application directory contained the source code of an existing Rails application, the Bitnami Rails Development Container would load the existing application instead of bootstrapping a new one.
 
-After the WEBrick application server has been launched in the `myapp` service, visit http://localhost:3000 in your favorite web browser and you'll be greeted by the default Rails welcome page.
+After the WEBrick application server has been launched in the `myapp` service, visit http://localhost:3000 in your favourite web browser and you'll be greeted by the default Rails welcome page.
 
 In addition to the Rails Development Container, the [docker-compose.yml](https://raw.githubusercontent.com/bitnami/bitnami-docker-rails/master/docker-compose.yml) file also configures a MariaDB service to serve as the database backend of your Rails application.
 
@@ -138,19 +138,39 @@ Following are a few examples of launching some commonly used Rails development c
   $ docker-compose exec myapp bundle exec rake db:migrate
   ```
 
-  > **Note**
-  >
-  > Database migrations are automatically applied during the start up of the Rails Development Container. This means that the `myapp` service could also be restarted to apply the database migrations.
-  > ```bash
-  > $ docker-compose restart myapp
-  > ```
+> **Note**
+>
+> Database migrations are automatically applied during the start up of the Rails Development Container. This means that the `myapp` service could also be restarted to apply the database migrations.
+> ```bash
+> $ docker-compose restart myapp
+> ```
+
+## Configuring your database:
+
+You can configure the MariaDB hostname and database name to use for development purposes using the environment variables **MARIADB_HOST** & **MARIADB_DATABASE**.
+
+For example, you can configure your Rails app to use the `development-db` database running on the `my-mariadb` MariaDB server using the `docker-compose.yml` below:
+
+```yaml
+version: '2'
+
+services:
+  myapp::
+    image: bitnami/rails:latest
+    environment:
+      - MARIADB_HOST=my-mariadb
+      - MARIADB_DATABASE=development-db
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/app
+```
 
 ## Running additional services:
 
-  Sometimes, your application will require extra pieces, such as background processing tools like Resque
-or Sidekiq.
+Sometimes, your application will require extra pieces, such as background processing tools like Resque or Sidekiq.
 
-  For these cases, it is possible to re-use this container to be run as an additional
+For these cases, it is possible to re-use this container to be run as an additional
 service in your docker-compose file by modifying the command
 executed.
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Following are a few examples of launching some commonly used Rails development c
 
 ## Configuring your database:
 
-You can configure the MariaDB hostname and database name to use for development purposes using the environment variables **MARIADB_HOST** & **MARIADB_DATABASE**.
+You can configure the MariaDB hostname and database name to use for development purposes using the environment variables **DATABASE_HOST** & **DATABASE_NAME**.
 
 For example, you can configure your Rails app to use the `development-db` database running on the `my-mariadb` MariaDB server using the `docker-compose.yml` below:
 
@@ -158,8 +158,8 @@ services:
   myapp::
     image: bitnami/rails:latest
     environment:
-      - MARIADB_HOST=my-mariadb
-      - MARIADB_DATABASE=development-db
+      - DATABASE_HOST=my-mariadb
+      - DATABASE_NAME=development-db
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     labels:
       kompose.service.type: nodeport
     environment:
-      - DATABASE_URL=mysql2://mariadb/my_app_development
+      - MARIADB_HOST=mariadb
+      - MARIADB_DATABASE=my_app_development
     depends_on:
       - mariadb
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,9 @@ services:
   myapp:
     tty: true # Enables debugging capabilities when attached to this container.
     image: 'bitnami/rails:latest'
-    labels:
-      kompose.service.type: nodeport
     environment:
-      - MARIADB_HOST=mariadb
-      - MARIADB_DATABASE=my_app_development
+      - DATABASE_HOST=mariadb
+      - DATABASE_NAME=my_app_development
     depends_on:
       - mariadb
     ports:


### PR DESCRIPTION
**Description of the change**

This PR allows the users to configure the database to use by setting **DATABASE_HOST** and **DATABASE_NAME** env. variables.

 - fixes https://github.com/bitnami/bitnami-docker-rails/issues/47

The env. variable **DATABASE_URL** won't be used anymore.