### PR TITLE
introduce standalone rails engine

### DIFF
--- a/6/debian-10/rootfs/opt/bitnami/scripts/librails.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/librails.sh
@@ -110,18 +110,18 @@ rails_initialize() {
         bundle install
     else
         info "Creating new Rails project"
-	if ! is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
-          rails new "." --database "$DATABASE_TYPE"
-          # Set up database configuration
-          local database_path="$DATABASE_NAME"
-          [[ "$DATABASE_TYPE" = "sqlite3" ]] && database_path="db/${DATABASE_NAME}.sqlite3"
-          info "Configuring database host to ${DATABASE_HOST}"
-          replace_in_file "config/database.yml" "host:.*$" "host: ${DATABASE_HOST}"
-          info "Configuring database name to ${DATABASE_NAME}"
-          replace_in_file "config/database.yml" "database:.*$" "database: ${database_path}" "1,/test:/ "
-        elif is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
-          rails new "." --skip-active-record
-	fi
+        if is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
+            rails new "." --skip-active-record
+        else
+            rails new "." --database "$DATABASE_TYPE"
+            # Set up database configuration
+            local database_path="$DATABASE_NAME"
+            [[ "$DATABASE_TYPE" = "sqlite3" ]] && database_path="db/${DATABASE_NAME}.sqlite3"
+            info "Configuring database host to ${DATABASE_HOST}"
+            replace_in_file "config/database.yml" "host:.*$" "host: ${DATABASE_HOST}"
+            info "Configuring database name to ${DATABASE_NAME}"
+            replace_in_file "config/database.yml" "database:.*$" "database: ${database_path}" "1,/test:/ "
+        fi
     fi
 
     # Wait for database and initialize

--- a/6/debian-10/rootfs/opt/bitnami/scripts/librails.sh
+++ b/6/debian-10/rootfs/opt/bitnami/scripts/librails.sh
@@ -15,6 +15,7 @@
 # Load global variables used on Rails configuration.
 # Globals:
 #   RAILS_ENV
+#   SKIP_ACTIVE_RECORD
 #   SKIP_DB_SETUP
 #   SKIP_DB_WAIT
 #   RETRY_ATTEMPTS
@@ -31,6 +32,7 @@
 rails_env() {
     cat <<"EOF"
 RAILS_ENV="${RAILS_ENV:-development}"
+SKIP_ACTIVE_RECORD="${SKIP_ACTIVE_RECORD:-no}"
 SKIP_DB_SETUP="${SKIP_DB_SETUP:-no}"
 SKIP_DB_WAIT="${SKIP_DB_WAIT:-no}"
 RETRY_ATTEMPTS="${RETRY_ATTEMPTS:-30}"
@@ -47,6 +49,7 @@ EOF
 ########################
 # Validate settings in DATABASE_* env vars
 # Globals:
+#   SKIP_ACTIVE_RECORD
 #   SKIP_DB_SETUP
 #   SKIP_DB_WAIT
 #   RETRY_ATTEMPTS
@@ -77,6 +80,7 @@ rails_validate() {
         fi
     }
 
+    check_yes_no_value SKIP_ACTIVE_RECORD
     check_yes_no_value SKIP_DB_SETUP
     check_yes_no_value SKIP_DB_WAIT
     check_positive_value RETRY_ATTEMPTS
@@ -94,6 +98,11 @@ rails_validate() {
 #   None
 #########################
 rails_initialize() {
+    # Skip database intialization
+    if is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
+      export SKIP_DB_WAIT="yes"
+      export SKIP_DB_SETUP="yes"
+    fi
     # Initialize Rails project
     if [[ -f "config.ru" ]]; then
         info "Rails project found, skipping creation"
@@ -101,14 +110,18 @@ rails_initialize() {
         bundle install
     else
         info "Creating new Rails project"
-        rails new "." --database "$DATABASE_TYPE"
-        # Set up database configuration
-        local database_path="$DATABASE_NAME"
-        [[ "$DATABASE_TYPE" = "sqlite3" ]] && database_path="db/${DATABASE_NAME}.sqlite3"
-        info "Configuring database host to ${DATABASE_HOST}"
-        replace_in_file "config/database.yml" "host:.*$" "host: ${DATABASE_HOST}"
-        info "Configuring database name to ${DATABASE_NAME}"
-        replace_in_file "config/database.yml" "database:.*$" "database: ${database_path}" "1,/test:/ "
+	if ! is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
+          rails new "." --database "$DATABASE_TYPE"
+          # Set up database configuration
+          local database_path="$DATABASE_NAME"
+          [[ "$DATABASE_TYPE" = "sqlite3" ]] && database_path="db/${DATABASE_NAME}.sqlite3"
+          info "Configuring database host to ${DATABASE_HOST}"
+          replace_in_file "config/database.yml" "host:.*$" "host: ${DATABASE_HOST}"
+          info "Configuring database name to ${DATABASE_NAME}"
+          replace_in_file "config/database.yml" "database:.*$" "database: ${database_path}" "1,/test:/ "
+        elif is_boolean_yes "$SKIP_ACTIVE_RECORD"; then
+          rails new "." --skip-active-record
+	fi
     fi
 
     # Wait for database and initialize

--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ services:
   ...
 ```
 
+## Running without database:
+Sometimes, your application will be a service that will only communicate with 3rd party APIs or services
+or something similar where database interaction is not needed.
+
+For these cases, it is possible to re-use this container to be run as a standalone rails engine service
+in your docker-compose file by defining `SKIP_ACTIVE_RECORD` as an environment variable
+
+```yaml
+services:
+  ...
+  myapp:
+    image: bitnami/rails:latest
+    environment:
+      - SKIP_ACTIVE_RECORD=yes
+  ...
+```
+
 ## Running additional services:
 
 Sometimes, your application will require extra pieces, such as background processing tools like Resque


### PR DESCRIPTION
Hello,

This PR introduces the ability to use rails without depending on the database as there are cases that might need to use rails engine only. This will be done by defining an environment variable called `SKIP_ACTIVE_RECORD`.
If there are any changes needed let me know as I tried to make it small and simple as possible but of course, we might add a function that is responsible for creating the new application in both scenarios instead of writing the whole command again but I will be waiting for review
This PR closes #100 
Thank you